### PR TITLE
radio flux cut skeleton

### DIFF
--- a/fgspectra/frequency.py
+++ b/fgspectra/frequency.py
@@ -76,6 +76,41 @@ class Synchrotron(PowerLaw):
     pass
 
 
+class RadioSourcesFluxCut(Model):
+    """ Radio point source power law with amplitude from flux cut
+    
+    .. math:: f(\nu) = amp (\nu / \nu_0)^{\beta}
+    .. math:: amp = 
+    """
+    def eval(self, nu=None, nu_0=None, fluxcut=None, beta=None):
+        """ Evaluation of the SED
+
+        Parameters
+        ----------
+        nu: float or array
+            Frequency in GHz.
+        fluxcut: float or array
+            Flux cut in Jy
+        beta: float or array
+            Spectral index. Normally -2.5
+        nu_0: float
+            Reference frequency in Hz.
+
+        Returns
+        -------
+        sed: ndarray
+            The last dimension is the frequency dependence.
+            The leading dimensions are the broadcast between the hypothetic
+            dimensions of `beta` and `fluxcut`.
+        """
+        fluxcut = np.array(temp)[..., np.newaxis]
+        beta = np.array(beta)[..., np.newaxis]
+    
+        # Fill here with flux cut equations    
+    
+        return
+        
+
 class ModifiedBlackBody(Model):
     r""" Modified black body in K_RJ
 


### PR DESCRIPTION
Adding skeleton for flux cut calculation. Ultimately radio sources will be a FactorizedCrossSpectrum(frequency.PowerLaw, power.PowerLaw). With the appropriate indices (e.g. beta=-2.5 and alpha=0) or something similar. The amplitude is then set from the flux cut calculation. Hopefully that makes sense. We need Alex or others to implement the actual calculation please. 