### PR TITLE
Bandpass integration

### DIFF
--- a/fgspectra/cross.py
+++ b/fgspectra/cross.py
@@ -4,7 +4,6 @@ Models of cross-spectra
 This module draws inspiration from FGBuster (Davide Poletti and Josquin Errard)
 and BeFoRe (David Alonso and Ben Thorne).
 """
-from abc import ABC, abstractmethod
 import numpy as np
 from . import frequency as fgf
 from . import power as fgp

--- a/fgspectra/frequency.py
+++ b/fgspectra/frequency.py
@@ -41,6 +41,9 @@ def _bandpass_integration():
       and returns it
 
     '''
+    # It assumes that _bandpass_integration was called inside
+    # f(self, **kw) -- f is typically an eval method.
+    # Retrieve kw and (a copy of) f
     frame = inspect.currentframe().f_back
     kw = frame.f_locals
     self = kw['self']
@@ -53,7 +56,8 @@ def _bandpass_integration():
     res = np.trapz(f(self, **kw) * nus_transmittances[0][1], kw['nu'])
     # Append the frequency dimension and put res in its first entry
     res = res[..., np.newaxis] * np.array([1.]+[0.]*(len(nus_transmittances)-1))
-
+    
+    # Fill the remaining entries by iterating over the rest of the bandpasses
     for i_band, (nu, transmittance) in enumerate(nus_transmittances[1:], 1):
         kw['nu'] = nu
         res[..., i_band] = np.trapz(f(self, **kw) * transmittance, nu)

--- a/fgspectra/frequency.py
+++ b/fgspectra/frequency.py
@@ -30,15 +30,15 @@ def _bandpass_integration():
     at the very beginning.
     This function
 
-    * iterate over the ``nu`` argument of the caller
+    * iterates over the ``nu`` argument of the caller
       (while keeping all the other arguments fixed)
     * splits each element of the iteration in ``nu_band, transmittance``
     * integrates the caller function over the bandpass.
       ``np.trapz(caller(nu_band) * transmittance, nu_band)``
       Note that no normalization nor unit conversion is done to the
       transmittance
-    * Stack the output of the iteration (the frequency dimension is the last)
-      and return it
+    * stacks the output of the iteration (the frequency dimension is the last)
+      and returns it
 
     '''
     frame = inspect.currentframe().f_back

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,17 @@
 
 from setuptools import setup
 
-setup(name='fgspectra',
-      version='0.1',
-      description='Foreground SED and power spectrum library',
-      author='Simons Observatory fgspectra crew',
-      author_email='',
-      packages=['fgspectra'],
-      python_requires='>3',
-      include_package_data=True
-      )
+setup(
+    name='fgspectra',
+    version='0.1',
+    description='Foreground SED and power spectrum library',
+    author='Simons Observatory fgspectra crew',
+    author_email='',
+    packages=['fgspectra'],
+    python_requires='>3.5',
+    install_requires = [
+        'scipy',
+        'pyyaml',
+    ],
+    include_package_data=True
+)

--- a/tests/test_frequency.py
+++ b/tests/test_frequency.py
@@ -1,0 +1,31 @@
+import fgspectra.frequency as fgf
+from fgspectra.model import Model
+import numpy as np
+from numpy.testing import assert_allclose as aac
+
+
+def test_bandpass_integration():
+    frequency = np.array([[10., 20., 40.],
+                          [60., 90., 100.]])
+
+    transmittance = np.array([[1., 2., 4.],
+                              [1., 3., 1.]])
+
+    class Mock(Model):
+        def eval(self, nu=None, par=None):
+            if isinstance(nu, list):
+                return fgf._bandpass_integration()
+            return np.ones_like(nu) * np.array(par)[..., np.newaxis]
+
+    mock = Mock()
+    nus = list(zip(frequency, transmittance))
+
+    ress = mock(nus, 1)
+    refs = [75., 80.]
+    for res, ref in zip(refs, ress):
+        aac(res, ref)
+
+    ress = mock(nus, np.array([1., 2.]))
+    refs = np.array([[75., 80.], [150., 160.]])
+    for res, ref in zip(refs, ress):
+        aac(res, ref)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,8 +5,10 @@ from fgspectra import power as fgp
 from fgspectra import frequency as fgf
 import numpy as np
 
+
 def test_ksz():
     assert fgp.kSZ_bat() is not None
+
 
 def test_ACT_models():
     # define the models from fgspectra


### PR DESCRIPTION
Proposal to introduce bandpass integration in the frequency module using this function
https://github.com/simonsobs/fgspectra/blob/11ec4cd4c78ff7e93a9df63f6369ffb9e6cb853e/fgspectra/frequency.py#L22

See a minimal example in the dedicated test
https://github.com/simonsobs/fgspectra/blob/bb7f3e7b6ca853f475763cd9f3e51ca13e6f24f8/tests/test_frequency.py#L7

NOTE: the function does not perform any normalization of the band passes nor unit conversion before the integration. They are currently left to the users.
