### PR TITLE
Evaluation of Model from a single flat array

### DIFF
--- a/fgspectra/model.py
+++ b/fgspectra/model.py
@@ -188,19 +188,20 @@ class Model(ABC):
         if not hasattr(self, '_path_nones'):
             raise RuntimeError("You have to call prepare_for_arrays first")
         for path in self._path_nones:
+            inner_path = path
             inner_kwargs = self._template_kwargs
-            while len(path) > 1:
-                inner_kwargs = inner_kwargs[path[0]]
-                path.pop(0)
+            while len(inner_path) > 1:
+                inner_kwargs = inner_kwargs[inner_path[0]]
+                inner_path = inner_path[1:]
 
-            ref_val = inner_kwargs[path[0]]
+            ref_val = inner_kwargs[inner_path[0]]
             try:
                 # It's an array
-                inner_kwargs[path[0]] = x[:ref_val.size].reshape(ref_val.shape)
+                inner_kwargs[inner_path[0]] = x[:ref_val.size].reshape(ref_val.shape)
                 x = x[ref_val.size:]
             except AttributeError:
                 # It's a float
-                inner_kwargs[path[0]] = x[0]
+                inner_kwargs[inner_path[0]] = x[0]
                 x = x[1:]
         return self._template_kwargs
 

--- a/fgspectra/model.py
+++ b/fgspectra/model.py
@@ -3,6 +3,7 @@ import types
 import inspect
 import yaml
 import numpy as np
+from copy import deepcopy
 
 class Model(ABC):
     """ Abstract class for model definition
@@ -167,7 +168,7 @@ class Model(ABC):
         dictionaries of arguments. They are required to have at least all the
         arguments for which the default is None.
         """
-        self._template_kwargs = template_kwargs
+        self._template_kwargs = deepcopy(template_kwargs)
         self._update_path_nones()
 
     def kwargs2array(self, kwargs):


### PR DESCRIPTION
Suppose you have a Model `m` and a set of arguments `kwargs` such that `m.eval(**kwargs)` evaluates successfully `m`. To work with a flat numpy array `x` instead of the dictionary `kwargs`, first do

    m.prepare_for_array(kwargs)

It finds the free parameters (the `None` in the defaults of the `m`) and stores the path to reach them in `_path_nones`. It also stores a deep copy of kwargs in `_template_kwargs` that will be used do define the correspondence between the flat array and dictionary representation of the arguments of `eval`.

    m.array2kwargs(x)

unpacks a flat array into a dictionary while

    m.kwargs2array(kwargs)

takes from `kwargs` the values of the free parameters of `m` and stacks them into a flat array. Finally

    m.eval_array(x)

evaluates the model based on the flat array `x`.