### PR TITLE
Untested changes to diff management

### DIFF
--- a/fgspectra/model.py
+++ b/fgspectra/model.py
@@ -5,6 +5,13 @@ import yaml
 import numpy as np
 from copy import deepcopy
 
+# Conventions
+# * all the Models have an eval method that evaluates the model
+# * a parameters that is defaulted to None means that it is a free parameter
+# * The output fo the diff method ahs the same shape as that of eval but with
+#   one and only one extra dimension (the idea is that you use diff with
+#   minimizers, which work on flat array
+
 class Model(ABC):
 
     """ Abstract class for model definition
@@ -235,3 +242,13 @@ class Model(ABC):
                 val = val[p]
             res_list.append(np.array(val))
         return np.concatenate(res_list)
+
+
+def _apply(func, list_tuple_dict_or_value):
+    if isinstance(list_tuple_dict_or_value, (list, tuple)):
+        res = [_apply(func, v) for v in list_tuple_dict_or_value]
+    elif isinstance(list_tuple_dict_or_value, dict):
+        res = {k: _apply(func, v) for k, v in list_tuple_dict_or_value.items()}
+    else:
+        return func(list_tuple_dict_or_value)
+    return res


### PR DESCRIPTION
1. Agnostic about the structure of kwargs (which is the same of the
   output derivatives of the models): It can be a nested structure.
2. To address it, _apply applies a function to the leaf of nested
   dictionaries and lists
3. Drafted derivatives for CorrelatedFactorizedCrossSpectrum, Join
4. Derivatives wrt to multipoles are compressed from (ell, ..., ell)
   to (ell, ..., 1). This saves a lot of memory and operations, but
   may lead to mistakes. We have to decide whether it is worthwhile
5. Relatively minor changes here and there which, however, might break
   some compatibility with external codes
6. Only the variables should be passed to diff (i.e., those that are
   None in the defaults) and returned in the output dictionary/list