### PR TITLE
Add github action to automatically publish fgspectra release to pypi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,45 @@
+name: Build wheels and upload to PyPI
+
+on: [push, pull_request]
+
+jobs:
+
+  build_dist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.X'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install wheel
+          python setup.py sdist bdist_wheel
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+          retention-days: 1
+
+  upload_pypi:
+    needs: [build_dist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Set the https://github.com/marketplace/actions/pypi-publish github actions to automatically push `fgspectra` release to PyPI repository.

The `PYPI_API_TOKEN` needs to be set within the repository settings to make this working (see https://docs.github.com/en/actions/security-guides/encrypted-secrets)